### PR TITLE
Fix curl error on invalid resource

### DIFF
--- a/classes/controller/blocks/class-geography-set-controller.php
+++ b/classes/controller/blocks/class-geography-set-controller.php
@@ -436,6 +436,7 @@ function ajax_geography_get_ships() {
 					curl_setopt( $curl, CURLOPT_RETURNTRANSFER, TRUE );
 					$ship_data = curl_exec( $curl );
 					curl_close( $curl );
+					unset( $curl );
 					$ship_data = @json_decode($ship_data, TRUE);
 					if( isset( $ship_data[ 'features' ][ 0 ][ 'geometry' ][ 'coordinates' ] ) ) {
 						$ship_position = $ship_data[ 'features' ][ 0 ][ 'geometry' ][ 'coordinates' ];


### PR DESCRIPTION
Hello :wave: here's a short PR to fix a warning that frequently ends up in Sentry :wrench: 

Cf. https://sentry.greenpeace.org/organizations/greenpeace-org/issues/27/?project=2&query=is%3Aunresolved

In the loop on `ajax_geography_get_ships`, `$curl` can become a resource of type Unknown if we reuse it after `curl_close()`.
This happens on page `32693` (homepage ?) on a shortcode `shortcake_geography_set` with 3 ships in it, the 2nd one not being enabled.
- for the first ship, `$curl` is initialized and then `curl_close()` is called on it
- for the 2nd ship, `enabled_ship_2` is false, so `$curl` is not initialized again on line 429
- but it is not null, it still exists as a `resource of type Unknown` since it was closed, so it passes over line 431 and is used again

Using `unset($curl)` will ensure `$curl` is `null` after it has been used.